### PR TITLE
fix(fix inexact hint in locale): 修复清空摘要时的英文提示

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -56,7 +56,7 @@ delete-extra =
   }
 delete-abstract =
  {$count ->
-   [one]Are you sure you want to empty the abstract of the item? Are you sure you want to empty the extra of the item?
+   [one] Are you sure you want to empty the abstract of the item?
   *[other] Are you sure you want to empty the abstracts of the {$count} selected items?
   }
 # delete-abstract-sig                 =	Are you sure you want to empty the abstract of the item?

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -52,7 +52,7 @@ delete-extra =
   }
 delete-abstract =
  {$count ->
-   [one]您确定将所选条目的摘要清空?
+   [one] 您确定将所选条目的摘要清空?
   *[other] 您确定将所选{ $count }条目的摘要清空?
   }
 # delete-abstract-sig                 =	Are you sure you want to empty the abstract of the item?


### PR DESCRIPTION
- 修改了locale中英文字段的清空摘要提示词，删去了清空extra的提示，并增加空格，和其他提示保持一致
- 中文字段清空摘要提示词前增加一个空格，和其他保持一致