### PR TITLE
fix: broken favicon path

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -6,8 +6,8 @@
   "homepage_url": "__homepage__",
   "author": "__author__",
   "icons": {
-    "48": "chrome/content/icons/favicon@0.5x.png",
-    "96": "chrome/content/icons/favicon.png"
+    "48": "content/icons/favicon@0.5x.png",
+    "96": "content/icons/favicon.png"
   },
   "applications": {
     "zotero": {


### PR DESCRIPTION
- fix the broken favicon path in manifest.json after [b212cc6](https://github.com/redleafnew/delitemwithatt/commit/b212cc6ac4c6180d483c47006a1a7ffde8235528)
    - `chrome/content/icons/favicon.png` --> `content/icons/favicon.png`
